### PR TITLE
Format NVMe automatically with 512B block size.

### DIFF
--- a/rootfs-overlay/usr/bin/haos-flash
+++ b/rootfs-overlay/usr/bin/haos-flash
@@ -40,6 +40,15 @@ elif [ -b /dev/nvme0n1 ]
 then
 	echo "nvme0n1."
 	device=/dev/nvme0n1
+	nvme format -b 512 -f ${device}
+	if [ $? -eq 0 ]
+	then
+		echo "NVMe formatted with 512B block size."
+	else
+		echo "Formatting NVMe with 512B block size failed."
+		exit 1
+	fi
+
 	if [ -b /dev/mmcblk0 ]
 	then
 		echo "Clearing eMMC to ensure NVMe boot."


### PR DESCRIPTION
Make sure we're using 512B logical block size with NVMe, image-installation fails if logical block size is 4096B.