### PR TITLE
Format NVMe automatically with 512B block size.

### DIFF
--- a/rootfs-overlay/usr/bin/haos-flash
+++ b/rootfs-overlay/usr/bin/haos-flash
@@ -40,6 +40,15 @@ elif [ -b /dev/nvme0n1 ]
 then
 	echo "nvme0n1."
 	device=/dev/nvme0n1
+
+	if nvme format -b 512 -f ${device}
+	then
+		echo "NVMe formatted with 512B block size."
+	else
+		echo "Formatting NVMe with 512B block size failed."
+		exit 1
+	fi
+
 	if [ -b /dev/mmcblk0 ]
 	then
 		echo "Clearing eMMC to ensure NVMe boot."


### PR DESCRIPTION
Make sure we're using 512B logical block size with NVMe, image-installation fails if logical block size is 4096B.
---
Tried to install on 4096B formatted NVMe (SN850 on Yellow PoE with CM4 2GB Lite) and it failed silently (looked like successful installation, just steady green+red on next boot).

Caveat: I don't have a NVMe-disk without 512B block size support so cannot confirm does format actually error out.

Other option (instead of just plain formatting with -b 512) would be to interrogate NVMe which lbaf formats it has and check if lbads:9 is missing completely.

(pull-request-retry: renamed branch, refined patch & author-data)